### PR TITLE
add boolean 'false' in tooltip validator

### DIFF
--- a/src/js/vue-range-slider.js
+++ b/src/js/vue-range-slider.js
@@ -88,7 +88,7 @@ export default {
       type: [String, Boolean],
       default: 'always',
       validator(val) {
-        return ['hover', 'always'].indexOf(val) > -1
+        return ['hover', 'always', false].indexOf(val) > -1
       }
     },
     // 组件方向


### PR DESCRIPTION
Hi, I have an error when disabling the tooltip: Invalid prop: custom validator check failed for prop "tooltip".
I fixed the error will add a Boolean to the validator

Vue version 3.11.0